### PR TITLE
[Fixes #2] Use `@` renames to expect attributes instead of children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
  "time",
@@ -344,12 +344,12 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.16.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
 dependencies = [
  "cookie",
- "idna 0.2.3",
+ "idna 0.3.0",
  "log",
  "publicsuffix",
  "serde",
@@ -664,9 +664,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -803,17 +803,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1004,12 +993,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1378,9 +1361,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "async-compression",
  "base64",
@@ -1409,6 +1392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -1810,6 +1794,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.0", features = ["derive"] }
 clap-verbosity-flag = { version = "2.0" }
 lazy-regex = { version = "3.1.0" }
 reqwest = { version = "0.11", default-features = false, features = ["cookies", "gzip", "deflate", "multipart", "trust-dns", "rustls-tls-native-roots"] }
-quick-xml = { version = "=0.26.0", features = ["serialize"] } # Bumping up breaks `package.content` deserialization
+quick-xml = { version = "=0.31.0", features = ["serialize"] } # Bumping up breaks `package.content` deserialization
 scraper = { version = "0.18.1" }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ bytes = { version = "1.2" }
 clap = { version = "4.0", features = ["derive"] }
 clap-verbosity-flag = { version = "2.0" }
 lazy-regex = { version = "3.1.0" }
-reqwest = { version = "0.11", default-features = false, features = ["cookies", "gzip", "deflate", "multipart", "trust-dns", "rustls-tls-native-roots"] }
-quick-xml = { version = "=0.31.0", features = ["serialize"] } # Bumping up breaks `package.content` deserialization
+reqwest = { version = "0.11.24", default-features = false, features = ["cookies", "gzip", "deflate", "multipart", "trust-dns", "rustls-tls-native-roots"] }
+quick-xml = { version = "0.31.0", features = ["serialize"] } # Bumping up breaks `package.content` deserialization
 scraper = { version = "0.18.1" }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -11,6 +11,7 @@ use zip::ZipArchive;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
+#[serde(rename = "package")]
 struct Package {
     content: Content,
 }
@@ -22,19 +23,23 @@ struct Content {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Resources {
+    #[serde(rename = "@target")]
     target: String,
     resource: Vec<Resource>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Resource {
+    #[serde(rename = "@type")]
     r#type: String,
+    #[serde(rename = "@subdir")]
     subdir: String,
     includes: Vec<Includes>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Includes {
+    #[serde(rename = "@pattern")]
     pattern: String,
 }
 
@@ -120,6 +125,7 @@ mod test {
         let xml = quick_xml::se::to_string(&package).unwrap();
 
         println!("XML: {}", xml);
+        assert_eq!(xml, r#"<package><content><resources target="ATSAMV71J19B"><resource type="svd" subdir="samv71b/svd"><includes pattern="ATSAMV71J19B.svd"/></resource></resources></content></package>"#);
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

This fixes problems caused by bumping up versions of `quick-xml`. The mechanism distinguishing attributes from values have been put in motion.

## Scope
* Some `#[serde(rename = "")` clauses added
* Version of `quick-xml` bumped up and relieved from pinning